### PR TITLE
Optimisation for code

### DIFF
--- a/examples/terminal/main/st.c
+++ b/examples/terminal/main/st.c
@@ -3033,7 +3033,7 @@ const uint8_t nibble_inversion_lut[256] = {
 
 static void invert_framebuffer(uint8_t* fb) {
     for (int i=0; i < EPD_WIDTH / 2 * EPD_HEIGHT; i++) {
-        fb[i] = nibble_inversion_lut[fb[i]];
+        fb[i] ^= 0xFF;
     }
 }
 


### PR DESCRIPTION
As suggested by

Zaffer  10:09 PM - 24 March 2021
Browsing the terminal code, I came across the nibble_inversion_lut[]... Am I missing something here, or could the table be eliminated and the line where it's used changed as follows:
        fb[i] = nibble_inversion_lut[fb[i]];
to
        fb[i] ^= 0xFF; (edited)